### PR TITLE
bump go version to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,16 @@
 module github.com/projectdiscovery/networkpolicy
 
-go 1.14
+go 1.18
 
 require (
 	github.com/projectdiscovery/iputil v0.0.0-20210414194613-4b4d2517acf0
 	github.com/stretchr/testify v1.8.1
 	github.com/yl2chen/cidranger v1.0.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/projectdiscovery/mapcidr v0.0.6 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
# Description

Bump go version from 1.14 -> 1.18

closes #21 