### PR TITLE
feat: use bart algorithm for less memory usage + speed improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/projectdiscovery/networkpolicy
 go 1.21
 
 require (
+	github.com/gaissmai/bart v0.9.5
 	github.com/projectdiscovery/utils v0.0.82
 	github.com/stretchr/testify v1.9.0
 	github.com/yl2chen/cidranger v1.0.2
@@ -10,6 +11,7 @@ require (
 
 require (
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/bits-and-blooms/bitset v1.13.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/bits-and-blooms/bitset v1.13.0 h1:bAQ9OPNFYbGHV6Nez0tmNI0RiEu7/hxlYJRUA0wFAVE=
+github.com/bits-and-blooms/bitset v1.13.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gaissmai/bart v0.9.5 h1:vy+r4Px6bjZ+v2QYXAsg63vpz9IfzdW146A8Cn4GPIo=
+github.com/gaissmai/bart v0.9.5/go.mod h1:KHeYECXQiBjTzQz/om2tqn3sZF1J7hw9m6z41ftj3fg=
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=

--- a/networkpolicy_test.go
+++ b/networkpolicy_test.go
@@ -59,7 +59,7 @@ func Benchmark_Networkpolicy_CIDRRanger(b *testing.B) {
 		ranger := cidranger.NewPCTrieRanger()
 		for _, r := range DefaultIPv4DenylistRanges {
 			_, cidr, _ := net.ParseCIDR(r)
-			ranger.Insert(cidranger.NewBasicRangerEntry(*cidr))
+			_ = ranger.Insert(cidranger.NewBasicRangerEntry(*cidr))
 		}
 		contains, err := ranger.Contains(net.ParseIP("127.0.0.1"))
 		if err != nil || !contains {

--- a/networkpolicy_test.go
+++ b/networkpolicy_test.go
@@ -2,9 +2,13 @@ package networkpolicy
 
 import (
 	"log"
+	"net"
+	"net/netip"
 	"testing"
 
+	"github.com/gaissmai/bart"
 	"github.com/stretchr/testify/require"
+	"github.com/yl2chen/cidranger"
 )
 
 func TestValidateAddress(t *testing.T) {
@@ -47,5 +51,34 @@ func TestMultipleCases(t *testing.T) {
 	for _, tc := range testCases {
 		ok := np.Validate(tc.address)
 		require.Equal(t, tc.expectedValid, ok, "Unexpected result for address: "+tc.address)
+	}
+}
+
+func Benchmark_Networkpolicy_CIDRRanger(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ranger := cidranger.NewPCTrieRanger()
+		for _, r := range DefaultIPv4DenylistRanges {
+			_, cidr, _ := net.ParseCIDR(r)
+			ranger.Insert(cidranger.NewBasicRangerEntry(*cidr))
+		}
+		contains, err := ranger.Contains(net.ParseIP("127.0.0.1"))
+		if err != nil || !contains {
+			b.Fatalf("unexpected error: %v %v", err, contains)
+		}
+	}
+}
+
+func Benchmark_Networkpolicy_BartAlgorithm(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		rtbl := new(bart.Table[net.IP])
+		for _, r := range DefaultIPv4DenylistRanges {
+			parsed, _ := netip.ParsePrefix(r)
+			rtbl.Insert(parsed, nil)
+		}
+
+		_, contains := rtbl.Lookup(netip.MustParseAddr("127.0.0.1"))
+		if !contains {
+			b.Fatalf("expected to contain")
+		}
 	}
 }


### PR DESCRIPTION
- Replaced `cidranger` package with `bart` which provides a faster + more memory optimized lookup algorithm
- Improves memory usage as well as lookup speed by magnitudes

Benchmark results below

```console
goos: darwin
goarch: arm64
pkg: github.com/projectdiscovery/networkpolicy
Benchmark_Networkpolicy_CIDRRanger
Benchmark_Networkpolicy_CIDRRanger-10              66189             16658 ns/op           12896 B/op        620 allocs/op
Benchmark_Networkpolicy_BartAlgorithm
Benchmark_Networkpolicy_BartAlgorithm-10          409262              2786 ns/op            3200 B/op         73 allocs/op
PASS
```

References
- https://github.com/gaissmai/bart